### PR TITLE
Configure web server with ansible

### DIFF
--- a/ansible/roles/webserver/handlers/main.yml
+++ b/ansible/roles/webserver/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart apache
+  service:
+    name: httpd
+    state: restarted

--- a/ansible/roles/webserver/tasks/main.yml
+++ b/ansible/roles/webserver/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Set up some system packages
+  include: packages.yml
+
+- name: ensure apache is running
+  service:
+    name: httpd
+    state: started

--- a/ansible/roles/webserver/tasks/packages.yml
+++ b/ansible/roles/webserver/tasks/packages.yml
@@ -1,0 +1,12 @@
+---
+- name: 'Update APT package cache'
+  apt:
+    update_cache: yes
+    upgrade: safe
+  tags: admin
+
+- name: Install Apache 2.x
+  apt:
+    package: "apache2"
+    state: latest
+  tags: admin

--- a/ansible/roles/webserver/vars/main.yml
+++ b/ansible/roles/webserver/vars/main.yml
@@ -1,0 +1,2 @@
+http_port: 80
+max_clients: 200

--- a/ansible/webserver.yml
+++ b/ansible/webserver.yml
@@ -1,0 +1,4 @@
+---
+- hosts: 127.0.0.1
+  roles:
+    - webserver


### PR DESCRIPTION
Basic playbook to bring up apache. 
(looks broken because there is no systemd in docker but it's working)

```
root@secops-docker:/tmp/project/ansible# ansible-playbook webserver.yml
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does
not match 'all'

PLAY [127.0.0.1] *********************************************************************************************

TASK [Gathering Facts] ***************************************************************************************
ok: [127.0.0.1]

TASK [webserver : Update APT package cache] ******************************************************************
ok: [127.0.0.1]

TASK [webserver : Install Apache 2.x] ************************************************************************
changed: [127.0.0.1]

TASK [webserver : ensure apache is running] ******************************************************************
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "Could not find the requested service httpd: "}

PLAY RECAP ***************************************************************************************************
127.0.0.1                  : ok=3    changed=1    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   

```